### PR TITLE
Automatic deploys w/ CalVer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Lint
+      run: make lint
+    - name: Test
+      run: make test
+    - name: Install build dependencies
+      run: pip install -U setuptools wheel build calver
+    - name: Build
+      run: python -m build .
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "calver"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name='trove-classifiers',
-    version='2020.05.21',
     description="Canonical source for classifiers on PyPI (pypi.org).",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -26,4 +25,6 @@ setup(
     ],
     keywords="classifiers",
     packages=find_packages(),
+    use_calver=True,
+    setup_requires=["calver"],
 )


### PR DESCRIPTION
Fixes #3.

Switches to https://pypi.org/project/calver/ for versioning and auto-publishing with https://github.com/pypa/gh-action-pypi-publish.