### PR TITLE
Remove nonstandard ISCL short id from ISC license

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -223,7 +223,7 @@ classifiers = {
     "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
     "License :: OSI Approved :: Historical Permission Notice and Disclaimer (HPND)",
     "License :: OSI Approved :: IBM Public License",
-    "License :: OSI Approved :: ISC License (ISCL)",
+    "License :: OSI Approved :: ISC License",
     "License :: OSI Approved :: Intel Open Source License",
     "License :: OSI Approved :: Jabber Open Source License",
     "License :: OSI Approved :: MIT License",
@@ -745,6 +745,7 @@ classifiers = {
 # A mapping from the deprecated classifier name to a list of zero or more valid
 # classifiers that should replace it
 deprecated_classifiers = {
+    "License :: OSI Approved :: ISC License (ISCL)": ["License :: OSI Approved :: ISC License"],
     "Natural Language :: Ukranian": ["Natural Language :: Ukrainian"],
     "Topic :: Communications :: Chat :: AOL Instant Messenger": [],
 }


### PR DESCRIPTION
Request to add a new Trove classifier (or more exactly, to update an existing one).

## The name of the classifier(s) you would like to add:

* `License :: OSI Approved :: ISC License`

## Why do you want to add this classifier?
The canonical short identifier for the ISC License is simply ISC; see https://spdx.org/licenses/ISC.html.
This change aligns the ISC License classifier to match similar ones such as MIT License, BSD License, etc.
