### PR TITLE
Add NVIDIA CUDA 11.0 classifier to NVIDIA CUDA list

### DIFF
--- a/trove_classifiers/__init__.py
+++ b/trove_classifiers/__init__.py
@@ -19,6 +19,7 @@ classifiers = {
     "Environment :: GPU :: NVIDIA CUDA :: 10.0",
     "Environment :: GPU :: NVIDIA CUDA :: 10.1",
     "Environment :: GPU :: NVIDIA CUDA :: 10.2",
+    "Environment :: GPU :: NVIDIA CUDA :: 11.0",
     "Environment :: GPU :: NVIDIA CUDA :: 2.0",
     "Environment :: GPU :: NVIDIA CUDA :: 2.1",
     "Environment :: GPU :: NVIDIA CUDA :: 2.2",


### PR DESCRIPTION
This PR adds `Environment :: GPU :: NVIDIA CUDA :: 11.0`, to the pre-existing list of CUDA classifiers, following CUDA 11.0's release in [May 2020](https://developer.nvidia.com/cuda-toolkit-archive).