### PR TITLE
Add "Programming Language :: Kotlin" classifier

### DIFF
--- a/trove_classifiers/__init__.py
+++ b/trove_classifiers/__init__.py
@@ -375,6 +375,7 @@ classifiers = {
     "Programming Language :: Haskell",
     "Programming Language :: Java",
     "Programming Language :: JavaScript",
+    "Programming Language :: Kotlin",
     "Programming Language :: Lisp",
     "Programming Language :: Logo",
     "Programming Language :: ML",


### PR DESCRIPTION
Request to add a new Trove classifier. Closes #41

## The name of the classifier(s) you would like to add:

* `Programming Language :: Kotlin`

## Why do you want to add this classifier?
Kotlin is a quite popular language, and also [this particular package](https://pypi.org/project/kotlin-jupyter-kernel/) needs it now.
