### PR TITLE
Add the "Framework :: Django CMS :: 3.8" classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -93,6 +93,7 @@ classifiers = {
     "Framework :: Django CMS :: 3.5",
     "Framework :: Django CMS :: 3.6",
     "Framework :: Django CMS :: 3.7",
+    "Framework :: Django CMS :: 3.8",
     "Framework :: Flake8",
     "Framework :: Flask",
     "Framework :: Hypothesis",


### PR DESCRIPTION
Request to add a new Trove classifier.

* `Framework :: Django CMS :: 3.8`

## Why do you want to add this classifier?

The django CMS team is preparing the 3.8 release and would like to include the new classifier.:

* https://github.com/divio/django-cms/pull/6886/files#diff-2eeaed663bd0d25b7e608891384b7298R34
