### PR TITLE
Add the "Framework :: AWS CDK :: 1" classifier

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 How to contributing to this package.
 
 ## Running tests
-Run `make tests`. This checks whether the auto-generated list of classifiers
+Run `make test`. This checks whether the auto-generated list of classifiers
 matches the input source.
 
 ## Running linting

--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -59,6 +59,8 @@ classifiers = {
     "Environment :: X11 Applications :: Gnome",
     "Environment :: X11 Applications :: KDE",
     "Environment :: X11 Applications :: Qt",
+    "Framework :: AWS CDK",
+    "Framework :: AWS CDK :: 1",
     "Framework :: AiiDA",
     "Framework :: AsyncIO",
     "Framework :: BEAT",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: AWS CDK`
* `Framework :: AWS CDK :: 1`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->
User experience study participants for the AWS CDK mentioned they would like to
be able to identify AWS CDK (Cloud Development Kit) packages in PyPI using a
standard trove classifier, which sounds like a good idea.

Since we are going to release a v2 "soon" (aws/aws-cdk-rfcs#156), I am already
requesting the `:: 1` suffix. I'll file a separate request to add a `:: 2`
suffix once CDK v2.0 is ready for initial release (unless you'd rather I add it
right away).

More info on the project: https://github.com/aws/aws-cdk
