### PR TITLE
Add Markdown markup classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -728,6 +728,7 @@ classifiers = {
     "Topic :: Text Processing :: Markup",
     "Topic :: Text Processing :: Markup :: HTML",
     "Topic :: Text Processing :: Markup :: LaTeX",
+    "Topic :: Text Processing :: Markup :: Markdown",
     "Topic :: Text Processing :: Markup :: SGML",
     "Topic :: Text Processing :: Markup :: VRML",
     "Topic :: Text Processing :: Markup :: XML",


### PR DESCRIPTION


## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Topic :: Text Processing :: Markup :: Markdown`

## Why do you want to add this classifier?
A package that does text processing of Markdown files can reference this classifier. I'm developing a package that needs it.
