### PR TITLE
Add reStructuredText markup classifier.

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -729,10 +729,10 @@ classifiers = {
     "Topic :: Text Processing :: Markup :: HTML",
     "Topic :: Text Processing :: Markup :: LaTeX",
     "Topic :: Text Processing :: Markup :: Markdown",
-    "Topic :: Text Processing :: Markup :: reStructuredText",
     "Topic :: Text Processing :: Markup :: SGML",
     "Topic :: Text Processing :: Markup :: VRML",
     "Topic :: Text Processing :: Markup :: XML",
+    "Topic :: Text Processing :: Markup :: reStructuredText",
     "Topic :: Utilities",
     "Typing :: Typed",
 }

--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -729,6 +729,7 @@ classifiers = {
     "Topic :: Text Processing :: Markup :: HTML",
     "Topic :: Text Processing :: Markup :: LaTeX",
     "Topic :: Text Processing :: Markup :: Markdown",
+    "Topic :: Text Processing :: Markup :: reStructuredText",
     "Topic :: Text Processing :: Markup :: SGML",
     "Topic :: Text Processing :: Markup :: VRML",
     "Topic :: Text Processing :: Markup :: XML",

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -6,7 +6,13 @@ from tests.lib import trove_tester, InvalidClassifier
 @pytest.mark.parametrize(
     "classifiers, deprecated_classifiers",
     [
-        ({"Foo :: Bar", "Foo :: Bar :: Baz",}, {}),
+        (
+            {
+                "Foo :: Bar",
+                "Foo :: Bar :: Baz",
+            },
+            {},
+        ),
         ({"Foo :: Bar"}, {"Biz :: Baz": ["Foo :: Bar"]}),
     ],
 )
@@ -17,15 +23,23 @@ def test_success(classifiers, deprecated_classifiers):
 @pytest.mark.parametrize(
     "classifiers, deprecated_classifiers, expected",
     [
-        ({"Foo", "Foo :: Bar"}, {}, "Top-level classifier 'Foo' is invalid",),
+        (
+            {"Foo", "Foo :: Bar"},
+            {},
+            "Top-level classifier 'Foo' is invalid",
+        ),
         ({"Foo :: Bar :: Baz"}, {}, "Classifier 'Foo :: Bar' is missing"),
         (
-            {"Foo :: Bar",},
+            {
+                "Foo :: Bar",
+            },
             {"Biz :: Baz": ["Bing :: Bang"]},
             "Classifier 'Bing :: Bang' does not exist",
         ),
         (
-            {"Foo :: Bar",},
+            {
+                "Foo :: Bar",
+            },
             {"Foo :: Bar": []},
             "Classifier 'Foo :: Bar' in both valid and deprecated classifiers",
         ),
@@ -43,9 +57,21 @@ def test_success(classifiers, deprecated_classifiers):
             {},
             "Classifiers starting or ending with whitespace are invalid",
         ),
-        ({"Foo: :: Bar"}, {}, "Classifiers containing ':' are invalid",),
-        ({"Foo :: B:ar"}, {}, "Classifiers containing ':' are invalid",),
-        ({"Foo :: Bar: Baz"}, {}, "Classifiers containing ':' are invalid",),
+        (
+            {"Foo: :: Bar"},
+            {},
+            "Classifiers containing ':' are invalid",
+        ),
+        (
+            {"Foo :: B:ar"},
+            {},
+            "Classifiers containing ':' are invalid",
+        ),
+        (
+            {"Foo :: Bar: Baz"},
+            {},
+            "Classifiers containing ':' are invalid",
+        ),
     ],
 )
 def test_failure(classifiers, deprecated_classifiers, expected):


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Topic :: Text Processing :: Markup :: reStructuredText`

This follows the same template as the one proposed for Markdown: https://github.com/pypa/trove-classifiers/pull/45

## Why do you want to add this classifier?

reStructuredText is deeply present in the Python community and elsewhere as a robust markup language for technical documentation [since 2002](https://docutils.sourceforge.io/docs/ref/rst/introduction.html#history). Notable projects using it: [Linux kernel](https://lwn.net/Articles/692704/), CMake, Sphinx...