### PR TITLE
Add the "Framework :: Kedro" classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -102,6 +102,7 @@ classifiers = {
     "Framework :: IDLE",
     "Framework :: IPython",
     "Framework :: Jupyter",
+    "Framework :: Kedro",
     "Framework :: Lektor",
     "Framework :: Masonite",
     "Framework :: Matplotlib",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:
* `Framework :: Kedro`

## Why do you want to add this classifier?
[Kedro](https://github.com/quantumblacklabs/kedro) is an open-source Python framework that applies software engineering best-practice to data and machine-learning pipelines. [The functionality of Kedro can be extended using its `plugin` framework, which is designed to reduce the complexity involved in creating new features for Kedro while allowing you to inject additional commands into the CLI. Plugins are developed as separate Python packages that exist outside of any Kedro project.](https://kedro.readthedocs.io/en/0.16.4/07_extend_kedro/05_plugins.html) A trove classifier for the framework would help users find relevant plugins.

The following (non-exhaustive list of) projects would use this classifier:

* https://pypi.org/project/kedro-viz/
* https://pypi.org/project/kedro-docker/
* https://pypi.org/project/kedro-airflow/
* https://pypi.org/project/kedro-wings/
* https://pypi.org/project/kedro-great/
* https://pypi.org/project/kedro-mlflow/
* https://pypi.org/project/kedro-grpc-server/
* https://pypi.org/project/kedro-argo/
* https://pypi.org/project/kedro-static-viz/
* https://pypi.org/project/kedro-pandas-profiling/
* https://pypi.org/project/steel-toes/

The above list includes both plugins maintained by the Kedro team and those developed by community members. Almost all Kedro plugins start with the "kedro-" prefix.