### PR TITLE
Added "The Unlicense" OSI Approved license #48

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -244,6 +244,7 @@ classifiers = {
     "License :: OSI Approved :: Sleepycat License",
     "License :: OSI Approved :: Sun Industry Standards Source License (SISSL)",
     "License :: OSI Approved :: Sun Public License",
+    "License :: OSI Approved :: The Unlicense",
     "License :: OSI Approved :: Universal Permissive License (UPL)",
     "License :: OSI Approved :: University of Illinois/NCSA Open Source License",
     "License :: OSI Approved :: Vovida Software License 1.0",

--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -244,7 +244,7 @@ classifiers = {
     "License :: OSI Approved :: Sleepycat License",
     "License :: OSI Approved :: Sun Industry Standards Source License (SISSL)",
     "License :: OSI Approved :: Sun Public License",
-    "License :: OSI Approved :: The Unlicense",
+    "License :: OSI Approved :: The Unlicense (Unlicense)",
     "License :: OSI Approved :: Universal Permissive License (UPL)",
     "License :: OSI Approved :: University of Illinois/NCSA Open Source License",
     "License :: OSI Approved :: Vovida Software License 1.0",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `License :: OSI Approved :: The Unlicense`

Version with SPDX Identifier: (From latest commit)
* `License :: OSI Approved :: The Unlicense (Unlicense)`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->
The Unlicense was approved by OSI (https://opensource.org/licenses/unlicense)
According to [this](https://github.com/search?l=Python&q=license%3Aunlicense&type=Repositories) search query there are about 15000 Python projects on GitHub using "The Unlicense" license.