### PR TITLE
Add NVIDIA CUDA 11.1 classifier to NVIDIA CUDA list

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -20,6 +20,7 @@ classifiers = {
     "Environment :: GPU :: NVIDIA CUDA :: 10.1",
     "Environment :: GPU :: NVIDIA CUDA :: 10.2",
     "Environment :: GPU :: NVIDIA CUDA :: 11.0",
+    "Environment :: GPU :: NVIDIA CUDA :: 11.1",    
     "Environment :: GPU :: NVIDIA CUDA :: 2.0",
     "Environment :: GPU :: NVIDIA CUDA :: 2.1",
     "Environment :: GPU :: NVIDIA CUDA :: 2.2",

--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -20,7 +20,7 @@ classifiers = {
     "Environment :: GPU :: NVIDIA CUDA :: 10.1",
     "Environment :: GPU :: NVIDIA CUDA :: 10.2",
     "Environment :: GPU :: NVIDIA CUDA :: 11.0",
-    "Environment :: GPU :: NVIDIA CUDA :: 11.1",    
+    "Environment :: GPU :: NVIDIA CUDA :: 11.1",
     "Environment :: GPU :: NVIDIA CUDA :: 2.0",
     "Environment :: GPU :: NVIDIA CUDA :: 2.1",
     "Environment :: GPU :: NVIDIA CUDA :: 2.2",


### PR DESCRIPTION
This PR adds `Environment :: GPU :: NVIDIA CUDA :: 11.1`, to the pre-existing list of CUDA classifiers, following CUDA 11.1's release in [Sept 2020](https://developer.nvidia.com/cuda-toolkit-archive).