### PR TITLE
Add Framework :: aiohttp classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -159,6 +159,7 @@ classifiers = {
     "Framework :: Zope :: 5",
     "Framework :: Zope2",
     "Framework :: Zope3",
+    "Framework :: aiohttp",
     "Framework :: napari",
     "Framework :: tox",
     "Intended Audience :: Customer Service",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: aiohttp`

## Why do you want to add this classifier?

https://github.com/aio-libs/aiohttp is very widely used in the Python community. 
It has 13M downloads per month at the moment of writing: https://pypistats.org/packages/aiohttp
More than 50 libraries officially claim that they are built on top of aiohttp: https://docs.aiohttp.org/en/stable/third_party.html
Many more libraries exist but out of the list.
libraries.io claims that 1141 PyPI packages depend on aiohttp: https://libraries.io/pypi/aiohttp/dependents

Adding a trove classifier would benefit the project as it will make related projects more discoverable. 
aiohttp already has a big and stable ecosystem, adding a dedicated classifier simplifies the searching.

Fixes #54