### PR TITLE
Added classifier for Django v3.2

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -91,6 +91,7 @@ classifiers = {
     "Framework :: Django :: 2.2",
     "Framework :: Django :: 3.0",
     "Framework :: Django :: 3.1",
+    "Framework :: Django :: 3.2",
     "Framework :: Django CMS",
     "Framework :: Django CMS :: 3.4",
     "Framework :: Django CMS :: 3.5",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `"Framework :: Django :: 3.2",`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

We're branching `stable/3.2.x` today (2021-01-14), releasing Django 3.2a1 on Tuesday (2021-01-19). Folks will immediately begin adding Django 3.2 compatibility and we'd like to have the classifier in place ASAP if we can. 

Thanks. 
