### PR TITLE
add MIT-0 license

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -228,6 +228,7 @@ classifiers = {
     "License :: OSI Approved :: Intel Open Source License",
     "License :: OSI Approved :: Jabber Open Source License",
     "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: MIT No Attribution License",
     "License :: OSI Approved :: MITRE Collaborative Virtual Workspace License (CVW)",
     "License :: OSI Approved :: MirOS License (MirOS)",
     "License :: OSI Approved :: Motosoto License",

--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -228,7 +228,7 @@ classifiers = {
     "License :: OSI Approved :: Intel Open Source License",
     "License :: OSI Approved :: Jabber Open Source License",
     "License :: OSI Approved :: MIT License",
-    "License :: OSI Approved :: MIT No Attribution License",
+    "License :: OSI Approved :: MIT No Attribution License (MIT-0)",
     "License :: OSI Approved :: MITRE Collaborative Virtual Workspace License (CVW)",
     "License :: OSI Approved :: MirOS License (MirOS)",
     "License :: OSI Approved :: Motosoto License",


### PR DESCRIPTION
add MIT-0 license, an OSI approved license documented at https://opensource.org/licenses/MIT-0
fixes https://github.com/pypa/trove-classifiers/issues/58

Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Your :: Trove :: Classifier`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->
