### PR TITLE
Add classifer for Ansible automation system

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -63,6 +63,7 @@ classifiers = {
     "Framework :: AWS CDK",
     "Framework :: AWS CDK :: 1",
     "Framework :: AiiDA",
+    "Framework :: Ansible",
     "Framework :: AsyncIO",
     "Framework :: BEAT",
     "Framework :: BFG",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Ansible`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

[Ansible](https://pypi.org/p/ansible) is an IT automation system for configuration management, application deployment, provisioning, network automation etc. It's written in Python, as is much of the surrounding ecosystem (e.g. [ara](https://pypi.org/p/ara), [molecule](https://pypi.org/p/molecule), [ansible-lint](https://pypi.org/p/ansible-lint), [ansible-runnner](https://pypi.org/p/ansible-runner), [awx](https://github.com/ansible/awx))

Around [780 projects mention Ansible on PyPI](https://pypi.org/search/?q=ansible). Many of these are using Ansible as an installation method. I estimate 100-300 would consider the classifier applicable. Having the classifier would allow users to find projects that build on Ansible, rather than happen to use it, similar to the situation with `Framework :: Tox`.
