### PR TITLE
Add NVIDIA CUDA 11.2 trove classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -41,6 +41,7 @@ sorted_classifiers = [
     "Environment :: GPU :: NVIDIA CUDA :: 10.2",
     "Environment :: GPU :: NVIDIA CUDA :: 11.0",
     "Environment :: GPU :: NVIDIA CUDA :: 11.1",
+    "Environment :: GPU :: NVIDIA CUDA :: 11.2",
     "Environment :: Handhelds/PDA's",
     "Environment :: MacOS X",
     "Environment :: MacOS X :: Aqua",


### PR DESCRIPTION
## The name of the classifier(s) you would like to add:

Environment :: GPU :: NVIDIA CUDA :: 11.2

## Why do you want to add this classifier?

NVIDIA CUDA 11.2 has been released: https://developer.nvidia.com/cuda-downloads

FYI: @av8ramit @mihaimaruseac