### PR TITLE
Add `Framework :: aiohttp` classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -162,6 +162,7 @@ sorted_classifiers = [
     "Framework :: Zope :: 3",
     "Framework :: Zope :: 4",
     "Framework :: Zope :: 5",
+    "Framework :: aiohttp",
     "Framework :: napari",
     "Framework :: tox",
     "Intended Audience :: Customer Service",


### PR DESCRIPTION
Co-Authored-By: Andrew Svetlov <andrew.svetlov@gmail.com>

Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: aiohttp`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->
https://github.com/aio-libs/aiohttp is very widely used in the Python community.
It has 13M downloads per month at the moment of writing: https://pypistats.org/packages/aiohttp
More than 50 libraries officially claim that they are built on top of aiohttp: https://docs.aiohttp.org/en/stable/third_party.html
Many more libraries exist but out of the list.
https://libraries.io claims that 1141 PyPI packages depend on aiohttp: https://libraries.io/pypi/aiohttp/dependents

Adding a trove classifier would benefit the project as it will make related projects more discoverable.
aiohttp already has a big and stable ecosystem, adding a dedicated classifier simplifies the searching.

Fixes #54
Resolves #55