### PR TITLE
Add the 'Framework :: Celery' trove classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -75,6 +75,7 @@ sorted_classifiers = [
     "Framework :: Buildout :: Recipe",
     "Framework :: CastleCMS",
     "Framework :: CastleCMS :: Theme",
+    "Framework :: Celery",
     "Framework :: Chandler",
     "Framework :: CherryPy",
     "Framework :: CubicWeb",


### PR DESCRIPTION
Request to add a new Trove classifier.

Fixes #16.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: Celery`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->
We'd like to create a community of projects for Celery and present related projects in our documentation automatically just like pytest does.