### PR TITLE
Add Django :: 4.0 classifier.

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -94,6 +94,7 @@ sorted_classifiers = [
     "Framework :: Django :: 3.0",
     "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.0",
     "Framework :: Django CMS",
     "Framework :: Django CMS :: 3.4",
     "Framework :: Django CMS :: 3.5",


### PR DESCRIPTION
Request to add a new Trove classifier.

* `Framework :: Django :: 4.0`

## Why do you want to add this classifier?

Django 4.0 alpha was released on September 21, 2021. See: https://www.djangoproject.com/weblog/2021/sep/21/django-40-alpha-1-released/