### PR TITLE
Add classifier Framework :: Datasette

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -83,6 +83,7 @@ sorted_classifiers = [
     "Framework :: CherryPy",
     "Framework :: CubicWeb",
     "Framework :: Dash",
+    "Framework :: Datasette",
     "Framework :: Django",
     "Framework :: Django :: 1.4",
     "Framework :: Django :: 1.5",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Datasette`

## Why do you want to add this classifier?

[Datasette](https://datasette.io/) is a tool for exploring and publishing data, which provides a web application for exploring SQLite databases and a mechanism for publishing those databases online.

A key feature of Datasette is its plugin system: plugins can be built that add additional features such as visualization tools, new output formats, custom SQL functions and more.

The official plugins directory at https://datasette.io/plugins currently lists 71 plugins, and there are even more that haven't been listed there yet as a search for `datasette` on PyPI confirms: https://pypi.org/search/?q=datasette (157 results today).

A classifier would be a great way to tie all of these plugins together.