### PR TITLE
Add new classifier "Typing :: Stubs Only"

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -785,6 +785,7 @@ sorted_classifiers = [
     "Topic :: Text Processing :: Markup :: XML",
     "Topic :: Text Processing :: Markup :: reStructuredText",
     "Topic :: Utilities",
+    "Typing :: Stubs Only",
     "Typing :: Typed",
 ]
 


### PR DESCRIPTION
Fixes #84

Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Typing :: Stubs Only`

## Why do you want to add this classifier?
See #84 
