### PR TITLE
Added django-cms 3.9 and 3.10 [#93]

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -113,6 +113,8 @@ sorted_classifiers = [
     "Framework :: Django CMS :: 3.6",
     "Framework :: Django CMS :: 3.7",
     "Framework :: Django CMS :: 3.8",
+    "Framework :: Django CMS :: 3.9",
+    "Framework :: Django CMS :: 3.10",
     "Framework :: FastAPI",
     "Framework :: Flake8",
     "Framework :: Flask",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Django CMS :: 3.9`
* `Framework :: Django CMS :: 3.10`

## Why do you want to add this classifier?

As mentioned in #93, django-cms 3.9 released in June 2021 and 3.10 is currently at RC2 with final release coming soon

Fixes #93 