### PR TITLE
Add type hints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ test: .state/env/pyvenv.cfg
 lint: .state/env/pyvenv.cfg
 	$(BINDIR)/black --check bin setup.py src tests
 	$(BINDIR)/python bin/sort.py src/trove_classifiers/__init__.py
+	$(BINDIR)/mypy src
 
 reformat: .state/env/pyvenv.cfg
 	$(BINDIR)/black tests src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "wheel", "calver"]
 build-backend = "setuptools.build_meta"
+
+[mypy]
+strict = true
+warn_unreachable = true

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,3 +2,4 @@ black
 jinja2
 natsort
 pytest
+mypy

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,12 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
+        "Typing :: Typed",
     ],
     keywords="classifiers",
     package_dir={"": "src"},
     packages=find_packages(where="src"),
+    package_data={"": ["py.typed"]},
     use_calver=True,
     setup_requires=["calver"],
 )


### PR DESCRIPTION
Since no methods or similar are involved, just add a 'py.typed' file and the typing trove

Closes #95