### PR TITLE
Add classifier for CUDA 11.6

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -45,6 +45,7 @@ sorted_classifiers = [
     "Environment :: GPU :: NVIDIA CUDA :: 11.3",
     "Environment :: GPU :: NVIDIA CUDA :: 11.4",
     "Environment :: GPU :: NVIDIA CUDA :: 11.5",
+    "Environment :: GPU :: NVIDIA CUDA :: 11.6",
     "Environment :: Handhelds/PDA's",
     "Environment :: MacOS X",
     "Environment :: MacOS X :: Aqua",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Environment :: GPU :: NVIDIA CUDA :: 11.6`

## Why do you want to add this classifier?

CUDA 11.6 was out recently and our product releases cannot be uploaded to PyPI without this classifier added.

cc: @jakirkham