### PR TITLE
Add "Framework :: AWS CDK :: 2" classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -67,6 +67,7 @@ sorted_classifiers = [
     "Environment :: X11 Applications :: Qt",
     "Framework :: AWS CDK",
     "Framework :: AWS CDK :: 1",
+    "Framework :: AWS CDK :: 2",
     "Framework :: AiiDA",
     "Framework :: Ansible",
     "Framework :: AnyIO",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: AWS CDK :: 2`

## Why do you want to add this classifier?

We had introduced the version 1 classifier about 2 years ago (https://github.com/pypa/trove-classifiers/pull/44), and we have GA's CDK v2 a while ago, and it recently came to my attention that the v2 code is still using the v1 classifier (sorry about that).

That classifier would be attached to libraries that build against/support the v2 of the AWS CDK. To get a sense of the community packages that could/should use this new classifier variation, you can refer to the following ConstructHub search results (all CDKv2 libraries that are available in Python):

https://constructs.dev/search?q=&cdk=aws-cdk&cdkver=2&langs=python&sort=downloadsDesc&offset=0

At time of writing, this is about 300 packages/projects.