### PR TITLE
Add Wagtail 3

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -190,6 +190,7 @@ sorted_classifiers = [
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 1",
     "Framework :: Wagtail :: 2",
+    "Framework :: Wagtail :: 3",
     "Framework :: ZODB",
     "Framework :: Zope",
     "Framework :: Zope2",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Wagtail :: 3`

## Why do you want to add this classifier?

Similar to other frameworks, it is useful for Wagtail to have per version classifiers, to easily locate compatible third-party packages.

[Wagtail RC3 is out](https://pypi.org/project/wagtail/3.0rc3/). And third-party packages actively work to become Wagtail 3 compatible and want to use this classifier.

Ref: https://github.com/wagtail/wagtail/pull/8486