### PR TITLE
Add license "MulanPSL-2.0"

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -276,6 +276,7 @@ sorted_classifiers = [
     "License :: OSI Approved :: Mozilla Public License 1.0 (MPL)",
     "License :: OSI Approved :: Mozilla Public License 1.1 (MPL 1.1)",
     "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+    "License :: OSI Approved :: Mulan Permissive Software License v2 (MulanPSL-2.0)",
     "License :: OSI Approved :: Nethack General Public License",
     "License :: OSI Approved :: Nokia Open Source License",
     "License :: OSI Approved :: Open Group Test Suite License",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `License :: OSI Approved :: Mulan Permissive Software License v2 (MulanPSL-2.0)`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->
