### PR TITLE
Added classifier for Django 4.1.

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -109,6 +109,7 @@ sorted_classifiers = [
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4",
     "Framework :: Django :: 4.0",
+    "Framework :: Django :: 4.1",
     "Framework :: Django CMS",
     "Framework :: Django CMS :: 3.4",
     "Framework :: Django CMS :: 3.5",


### PR DESCRIPTION
Request to add a new Trove classifier.

Hello 👋 

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: Django :: 4.1`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

It's release time for Django Version 4.1. 

The alpha is due next week (May 17) and folks will be wanted to declare compatibility.

Please can we add the classifier as per previous releases. 

Many thanks! 🎁 