### PR TITLE
explicit types

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -1,5 +1,7 @@
+from typing import Dict, List, Set
+
 # A set of classifier names
-sorted_classifiers = [
+sorted_classifiers: List[str] = [
     "Development Status :: 1 - Planning",
     "Development Status :: 2 - Pre-Alpha",
     "Development Status :: 3 - Alpha",
@@ -805,12 +807,12 @@ sorted_classifiers = [
     "Typing :: Typed",
 ]
 
-classifiers = set(sorted_classifiers)
+classifiers: Set[str] = set(sorted_classifiers)
 
 
 # A mapping from the deprecated classifier name to a list of zero or more valid
 # classifiers that should replace it
-deprecated_classifiers = {
+deprecated_classifiers: Dict[str, List[str]] = {
     "Natural Language :: Ukranian": ["Natural Language :: Ukrainian"],
     "Topic :: Communications :: Chat :: AOL Instant Messenger": [],
 }


### PR DESCRIPTION
For reasons that escape me, if I add a `reveal_type(deprecated_classifiers)` to `__init__.py`, mypy says:
```
$ mypy src/
src/trove_classifiers/__init__.py:817: note: Revealed type is "builtins.dict[builtins.str, builtins.object]"
Success: no issues found in 2 source files
```

But `object` isn't very helpful here.  So this MR makes the types completely explicit.