### PR TITLE
Added classifiers for `Windows 11`

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -377,6 +377,7 @@ sorted_classifiers: List[str] = [
     "Operating System :: Microsoft :: Windows :: Windows 8",
     "Operating System :: Microsoft :: Windows :: Windows 8.1",
     "Operating System :: Microsoft :: Windows :: Windows 10",
+    "Operating System :: Microsoft :: Windows :: Windows 11",
     "Operating System :: Microsoft :: Windows :: Windows 95/98/2000",
     "Operating System :: Microsoft :: Windows :: Windows CE",
     "Operating System :: Microsoft :: Windows :: Windows NT/2000",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Operating System :: Microsoft :: Windows :: Windows 11`

## Why do you want to add this classifier?
Trove classifiers exist for all Microsoft Windows versions up to Windows 10. Since then, versions 11 have been released. I propose the addition of the above a classifier
