### PR TITLE
Added django-cms 3.11 and 4.0

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -121,6 +121,8 @@ sorted_classifiers: List[str] = [
     "Framework :: Django CMS :: 3.8",
     "Framework :: Django CMS :: 3.9",
     "Framework :: Django CMS :: 3.10",
+    "Framework :: Django CMS :: 3.11",
+    "Framework :: Django CMS :: 4.0",
     "Framework :: FastAPI",
     "Framework :: Flake8",
     "Framework :: Flask",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: Django CMS :: 3.11`
* `Framework :: Django CMS :: 4.0`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->
These are necessary for the current version of django cms and the upcoming next major version.