### PR TITLE
Add "Framework :: Odoo :: 16.0" classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -154,6 +154,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Odoo :: 13.0",
     "Framework :: Odoo :: 14.0",
     "Framework :: Odoo :: 15.0",
+    "Framework :: Odoo :: 16.0",
     "Framework :: Opps",
     "Framework :: Paste",
     "Framework :: Pelican",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: Odoo :: 16.0`

## Why do you want to add this classifier?

The Odoo 16.0 branch has been created and it will be released in October.
