### PR TITLE
Add django CMS 4.1

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -124,6 +124,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Django CMS :: 3.10",
     "Framework :: Django CMS :: 3.11",
     "Framework :: Django CMS :: 4.0",
+    "Framework :: Django CMS :: 4.1",
     "Framework :: FastAPI",
     "Framework :: Flake8",
     "Framework :: Flask",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Django :: Django CMS :: 4.1`

## Why do you want to add this classifier?
This classifier is necessary for the upcoming next major community version of django CMS. 