### PR TITLE
Add Poetry classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -180,6 +180,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Plone :: Addon",
     "Framework :: Plone :: Core",
     "Framework :: Plone :: Theme",
+    "Framework :: Poetry",
     "Framework :: Pylons",
     "Framework :: Pyramid",
     "Framework :: Pytest",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: Poetry`

## Why do you want to add this classifier?
Poetry is an established package manager for Python projects. Since v1.2, it comes with a plugin API, which allows for the community to enhance and extend Poetry. It would be nice for such projects to have the option to mark themselves with a proper classifier.

