### PR TITLE
Add Pydantic classifiers

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -180,6 +180,8 @@ sorted_classifiers: List[str] = [
     "Framework :: Plone :: Addon",
     "Framework :: Plone :: Core",
     "Framework :: Plone :: Theme",
+    "Framework :: Pydantic",
+    "Framework :: Pydantic :: 1",
     "Framework :: Pylons",
     "Framework :: Pyramid",
     "Framework :: Pytest",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: Pydantic`
* `Framework :: Pydantic :: 1`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

There are a lot of projects using `Pydantic` like [FastAPI](https://github.com/tiangolo/fastapi)
Currently `Pydantic` is on `V1`. we are working on `V2`. That's why I've just added version 1

Pydantic issue link: https://github.com/pydantic/pydantic/issues/4935
CC: @samuelcolvin
