### PR TITLE
Add  `Framework :: Plone :: Distribution`

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -182,6 +182,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Plone :: 6.0",
     "Framework :: Plone :: Addon",
     "Framework :: Plone :: Core",
+    "Framework :: Plone :: Distribution",
     "Framework :: Plone :: Theme",
     "Framework :: Pydantic",
     "Framework :: Pydantic :: 1",

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -19,7 +19,6 @@ def trove_tester(classifiers, deprecated_classifiers):
 
         # Check the sub-classifiers
         for sub in split:
-
             # Check for whitespace
             if sub.strip().rstrip() != sub:
                 raise InvalidClassifier(
@@ -38,7 +37,6 @@ def trove_tester(classifiers, deprecated_classifiers):
 
     # Check the deprecated classifiers
     for deprecated_classifier, deprecated_by in deprecated_classifiers.items():
-
         # Check if the classifier is in both lists
         if deprecated_classifier in classifiers:
             raise InvalidClassifier(


### PR DESCRIPTION
Fix #131 
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Plone :: Distribution`

## Why do you want to add this classifier?

Plone just released the initial support for Distributions -- a pre-packaged version of Plone that includes specific features, themes, modules, and configurations. It is a convenient way to get a specific website up and running quickly, as the distribution includes everything needed to run that type of site. -- and we want to be able to segment new distributions from our existing addon ecosystem,

Even though the [plone.distribution](https://pypi.org/project/plone.distribution/) package is a new addition to Plone, over the years, the concept of a pre-packaged version of Plone has been used by many integrators and developers around the world. The following packages are good examples of **public** implementations of this concept:

* [brasil.gov.portal](https://pypi.org/project/brasil.gov.portal)
* [ploneintranet](https://pypi.org/project/ploneintranet)
* [senaite.core](https://pypi.org/project/senaite.core)
* [interlegis.intranetmodelo.policy](https://pypi.org/project/interlegis.intranetmodelo.policy)
* [interlegis.portalmodelo.policy](https://pypi.org/project/interlegis.portalmodelo.policy)
* [castle.cms](https://pypi.org/project/castle.cms)
* [design.plone.policy](https://pypi.org/project/design.plone.policy)
* [cpskin.policy](https://pypi.org/project/cpskin.policy)
* [onegov.intranet](https://pypi.org/project/onegov.intranet)

