### PR TITLE
feat: add a PyPy :: 3 classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -495,6 +495,7 @@ sorted_classifiers: List[str] = [
     "Programming Language :: Python :: Implementation :: Jython",
     "Programming Language :: Python :: Implementation :: MicroPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+    "Programming Language :: Python :: Implementation :: PyPy :: 3",
     "Programming Language :: Python :: Implementation :: Stackless",
     "Programming Language :: R",
     "Programming Language :: REBOL",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Programming Language :: Python :: Implementation :: PyPy :: 3`

## Why do you want to add this classifier?

* It is sometimes beneficial to be able to specify if a project support PyPy 2.7 or PyPy 3.x, and that's currently not possible