### PR TITLE
Add classifier for CUDA 12.1

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -53,6 +53,7 @@ sorted_classifiers: List[str] = [
     "Environment :: GPU :: NVIDIA CUDA :: 11.8",
     "Environment :: GPU :: NVIDIA CUDA :: 12",
     "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.0",
+    "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.1",
     "Environment :: Handhelds/PDA's",
     "Environment :: MacOS X",
     "Environment :: MacOS X :: Aqua",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.1`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

Follow-up of https://github.com/pypa/trove-classifiers/pull/124. CUDA 12.1.0 was released a few days ago.
