### PR TITLE
Add Pycsou Framework trove-classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -186,6 +186,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Plone :: Core",
     "Framework :: Plone :: Distribution",
     "Framework :: Plone :: Theme",
+    "Framework :: Pycsou",
     "Framework :: Pydantic",
     "Framework :: Pydantic :: 1",
     "Framework :: Pylons",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Pycsou`

## Why do you want to add this classifier?
The latest version of [Pycsou](https://matthieumeo.github.io/pycsou/html/index), v2, introduces an exciting new feature for users: the ability to develop plugin extensions through setuptools entrypoints. To make it even more convenient for users, we're currently working on a catalogue website that will showcase these plugins. The website will utilize the trove classifier to automatically discover and display the available plugins, making it easy for users to find and implement the ones they need.

