### PR TITLE
Add classifier for Wagtail 5

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -213,6 +213,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Wagtail :: 2",
     "Framework :: Wagtail :: 3",
     "Framework :: Wagtail :: 4",
+    "Framework :: Wagtail :: 5",
     "Framework :: ZODB",
     "Framework :: Zope",
     "Framework :: Zope2",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Wagtail :: 5`

## Why do you want to add this classifier?

[Wagtail 5.0rc1 has been released today](https://github.com/wagtail/wagtail/releases/tag/v5.0rc1). This release drops a number of deprecated APIs, and so a version-specific classifier will assist Wagtail site developers in locating third-party add-on packages that have been verified as compatible with Wagtail 5.