### PR TITLE
Separate build/publish job from release/tag job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
       run: python -m build .
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
+  release:
+    if: github.repository_owner == 'pypa'
+    runs-on: ubuntu-latest
+    steps:
     - name: Version
       id: version
       run: echo "::set-output name=version::$(python setup.py --version 2>/dev/null)"


### PR DESCRIPTION
Fixes #139.

(ref: https://sjramblings.io/github-actions-resource-not-accessible-by-integration)