### PR TITLE
Add Pydantic :: 2 classifier.

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -189,6 +189,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Pycsou",
     "Framework :: Pydantic",
     "Framework :: Pydantic :: 1",
+    "Framework :: Pydantic :: 2",
     "Framework :: Pylons",
     "Framework :: Pyramid",
     "Framework :: Pytest",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: Pydantic :: 2`

## Why do you want to add this classifier?
[Pydantic V2 alpha](https://github.com/pydantic/pydantic/releases/tag/v2.0a1) was released 
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->
