### PR TITLE
fix: incorrect specification of mypy section in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 requires = ["setuptools", "calver"]
 build-backend = "setuptools.build_meta"
 
-[mypy]
+[tool.mypy]
 strict = true
 warn_unreachable = true


### PR DESCRIPTION
Just noticed this was broken when looking at the pyproject.toml.