### PR TITLE
Add Plone 6.1 classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -182,6 +182,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Plone :: 5.2",
     "Framework :: Plone :: 5.3",
     "Framework :: Plone :: 6.0",
+    "Framework :: Plone :: 6.1",
     "Framework :: Plone :: Addon",
     "Framework :: Plone :: Core",
     "Framework :: Plone :: Distribution",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Plone :: 6.1`

## Why do you want to add this classifier?

Fixes #146 