### PR TITLE
Add Oceanography to Scientific/Engineering classifier.

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -702,6 +702,7 @@ sorted_classifiers: List[str] = [
     "Topic :: Scientific/Engineering :: Interface Engine/Protocol Translator",
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
+    "Topic :: Scientific/Engineering :: Oceanography",
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Scientific/Engineering :: Visualization",
     "Topic :: Security",


### PR DESCRIPTION
This seemed to be the place to add a new one -- please let me know if there's another way to propose a new classifier.

Note: we could do something like:
Met/Ocean Science, but there is already Atmospheric Science, I figured Oceanography made sense.

Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Topic :: Scientific/Engineering :: Oceanography`

## Why do you want to add this classifier?
There is Atmospheric Science, but nothing for us Water people :-)

We could have done Met/Ocean Science, but as Atmospheric Science is already there, Oceanography made sense.

We could also do "Ocean Science", but Oceanography is a more common term, at least at Universities in the US.


