### PR TITLE
Add Trove classifier for Django 5.0

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -122,6 +122,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
     "Framework :: Django CMS",
     "Framework :: Django CMS :: 3.4",
     "Framework :: Django CMS :: 3.5",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Django :: 5.0`

## Why do you want to add this classifier?

Django 5.0 alpha was released on Sep 18, 2023. See announcement at https://www.djangoproject.com/weblog/2023/sep/18/django-50-alpha-1-released/

Fixes #152 