### PR TITLE
Add `Framework :: MkDocs` classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -155,6 +155,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Lektor",
     "Framework :: Masonite",
     "Framework :: Matplotlib",
+    "Framework :: MkDocs",
     "Framework :: Nengo",
     "Framework :: Odoo",
     "Framework :: Odoo :: 8.0",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* Framework :: Mkdocs

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

There are many mkdocs plugins and themes on PyPI (https://pypi.org/search/?q=mkdocs). It'd be nice to have a way to classify and search for these. 
