### PR TITLE
Add the `NVIDIA CUDA :: 12 :: 12.2` classifier.

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -54,7 +54,7 @@ sorted_classifiers: List[str] = [
     "Environment :: GPU :: NVIDIA CUDA :: 12",
     "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.0",
     "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.1",
-    "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.2",    
+    "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.2",
     "Environment :: Handhelds/PDA's",
     "Environment :: MacOS X",
     "Environment :: MacOS X :: Aqua",

--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -54,6 +54,7 @@ sorted_classifiers: List[str] = [
     "Environment :: GPU :: NVIDIA CUDA :: 12",
     "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.0",
     "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.1",
+    "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.2",    
     "Environment :: Handhelds/PDA's",
     "Environment :: MacOS X",
     "Environment :: MacOS X :: Aqua",


### PR DESCRIPTION
It has been out for some time now:
https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html

Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.2`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->
We'd like to use it in https://pypi.org/project/tensorflow/, since its future releases will be using CUDA 12.2.
