### PR TITLE
Add Odoo 17 trove classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -168,6 +168,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Odoo :: 14.0",
     "Framework :: Odoo :: 15.0",
     "Framework :: Odoo :: 16.0",
+    "Framework :: Odoo :: 17.0",
     "Framework :: Opps",
     "Framework :: Paste",
     "Framework :: Pelican",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `"Framework :: Odoo :: 17.0"`

## Why do you want to add this classifier?

Odoo has just release version 17. https://github.com/odoo/odoo/tree/17.0
