### PR TITLE
Add `Programming Language :: Go`

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -457,6 +457,7 @@ sorted_classifiers: List[str] = [
     "Programming Language :: F#",
     "Programming Language :: Forth",
     "Programming Language :: Fortran",
+    "Programming Language :: Go",
     "Programming Language :: Haskell",
     "Programming Language :: Java",
     "Programming Language :: JavaScript",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Programming Language :: Go`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

To be able to mark something as written in Go. There are plenty of programming language classifiers, including more rare than Go and some archaic, I'm assuming there's no particular reason to exclude it.