### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         cache-dependency-path: .github/workflows/release.yml
     - name: Version
       id: version
-      run: echo "::set-output name=version::$(python setup.py --version 2>/dev/null)"
+      run: echo "version=$(python setup.py --version 2>/dev/null)" >> $GITHUB_OUTPUT
     - name: Tag
       uses: actions/create-release@v1
       env:


### PR DESCRIPTION
Update deprecated usage of save-state per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/