### PR TITLE
Add `Framework :: Sphinx :: Domain` classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -208,6 +208,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Scrapy",
     "Framework :: Setuptools Plugin",
     "Framework :: Sphinx",
+    "Framework :: Sphinx :: Domain",
     "Framework :: Sphinx :: Extension",
     "Framework :: Sphinx :: Theme",
     "Framework :: Trac",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: Sphinx :: Domain`

## Why do you want to add this classifier?

It would be a great addition to the `Extension` and `Theme` classifiers and help people find available Sphinx domains (there currently isn't a recognized way to group them) as evident in the official Sphinx docs (linking to the classifier on PyPi would be much cleaner): https://www.sphinx-doc.org/en/master/usage/domains/index.html#more-domains

This would also trickle down to tools like https://awesomesphinx.useblocks.com/ that help navigate the Sphinx ecosystem.

I created an [issue on the Sphinx repo](https://github.com/sphinx-doc/sphinx/issues/11562) to gather support and so far have 10 repo/pypi owners that have expressed interest:

- [matlabdomain](https://github.com/sphinx-doc/sphinx/issues/11562#issuecomment-1669208502)
- [sphinxcontrib-phpdomain](https://github.com/sphinx-doc/sphinx/issues/11562#issuecomment-1669742261)
- [sphinx-a4doc](https://github.com/sphinx-doc/sphinx/issues/11562#issuecomment-1695356747)
- [graphqldomain](https://github.com/sphinx-doc/sphinx/issues/11562#issuecomment-1700296342)
- [any](https://github.com/sphinx-doc/sphinx/issues/11562#issuecomment-1704569385)
- [VHDLDomain](https://github.com/sphinx-doc/sphinx/issues/11562#issuecomment-1705468310)
- [sphinx-bazel](https://github.com/sphinx-doc/sphinx/issues/11562#issuecomment-1736704740)
- [erlangdomain](https://github.com/sphinx-doc/sphinx/issues/11562#issuecomment-1822968375)
- [sphinx-compendia](https://github.com/sphinx-doc/sphinx/issues/11562#issuecomment-1823507649)
- [sphinxcontrib-chapeldomain](https://github.com/chapel-lang/sphinxcontrib-chapeldomain/issues/77)


