### PR TITLE
License :: OSI Approved :: Zero-Clause BSD (0BSD)

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -329,6 +329,7 @@ sorted_classifiers: List[str] = [
     "License :: OSI Approved :: Vovida Software License 1.0",
     "License :: OSI Approved :: W3C License",
     "License :: OSI Approved :: X.Net License",
+    "License :: OSI Approved :: Zero-Clause BSD (0BSD)",
     "License :: OSI Approved :: Zope Public License",
     "License :: OSI Approved :: zlib/libpng License",
     "License :: Other/Proprietary License",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:
* `License :: OSI Approved :: Zero-Clause BSD (0BSD)`

## Why do you want to add this classifier?
Why do the current classifiers not meet your need?
none of them are 0BSD

How many projects do you expect to use this new classifier?
hypothetically unbounded, at least one in the next week (or whenever you enable pypi registrations). it's gonna no worse than sleepycat which has precisely one public "project" from 2007, accd'g to https://pypi.org/search/?c=License+%3A%3A+OSI+Approved+%3A%3A+Sleepycat+License