### PR TITLE
Add classifier for Wagtail 6

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -224,6 +224,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Wagtail :: 3",
     "Framework :: Wagtail :: 4",
     "Framework :: Wagtail :: 5",
+    "Framework :: Wagtail :: 6",
     "Framework :: ZODB",
     "Framework :: Zope",
     "Framework :: Zope2",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Wagtail :: 6`

## Why do you want to add this classifier?

[Wagtail 6.0rc1](https://github.com/wagtail/wagtail/releases/tag/v6.0rc1) was released a week ago. Wagtail uses SemVer, and this release drops a number of deprecated APIs, and makes a number of breaking changes. A version-specific classifier will assist Wagtail site developers in locating third-party add-on packages that have been verified as compatible with Wagtail 6.