### PR TITLE
Add classifier: `License :: OSI Approved :: Educational Community License`

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -280,6 +280,8 @@ sorted_classifiers: List[str] = [
     "License :: OSI Approved :: Common Public License",
     "License :: OSI Approved :: Eclipse Public License 1.0 (EPL-1.0)",
     "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
+    "License :: OSI Approved :: Educational Community License v2.0 (ECL-2.0)",
+
     "License :: OSI Approved :: Eiffel Forum License",
     "License :: OSI Approved :: European Union Public Licence 1.0 (EUPL 1.0)",
     "License :: OSI Approved :: European Union Public Licence 1.1 (EUPL 1.1)",

--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -281,7 +281,6 @@ sorted_classifiers: List[str] = [
     "License :: OSI Approved :: Eclipse Public License 1.0 (EPL-1.0)",
     "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
     "License :: OSI Approved :: Educational Community License v2.0 (ECL-2.0)",
-
     "License :: OSI Approved :: Eiffel Forum License",
     "License :: OSI Approved :: European Union Public Licence 1.0 (EUPL 1.0)",
     "License :: OSI Approved :: European Union Public Licence 1.1 (EUPL 1.1)",

--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -280,7 +280,7 @@ sorted_classifiers: List[str] = [
     "License :: OSI Approved :: Common Public License",
     "License :: OSI Approved :: Eclipse Public License 1.0 (EPL-1.0)",
     "License :: OSI Approved :: Eclipse Public License 2.0 (EPL-2.0)",
-    "License :: OSI Approved :: Educational Community License v2.0 (ECL-2.0)",
+    "License :: OSI Approved :: Educational Community License, Version 2.0 (ECL-2.0)",
     "License :: OSI Approved :: Eiffel Forum License",
     "License :: OSI Approved :: European Union Public Licence 1.0 (EUPL 1.0)",
     "License :: OSI Approved :: European Union Public Licence 1.1 (EUPL 1.1)",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `License :: OSI Approved :: Educational Community License v2.0 (ECL-2.0)`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->
This OSI approved license is part of my project, and is missing from the approved classifiers. 