### PR TITLE
Add classifier for Hy

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -462,6 +462,7 @@ sorted_classifiers: List[str] = [
     "Programming Language :: Fortran",
     "Programming Language :: Go",
     "Programming Language :: Haskell",
+    "Programming Language :: Hy",
     "Programming Language :: Java",
     "Programming Language :: JavaScript",
     "Programming Language :: Kotlin",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Programming Language :: Hy`

## Why do you want to add this classifier?
[Hy](http://hylang.org) is a Lisp dialect based on Python that's been kicking around since 2012. Hy uses Python's packaging system, but it's possible for a Hy package to provide features not usable in pure Python, such as macros. It would be nice to have a classifier for packages specifically useful for Hy, particularly in advance of the release of Hy 1.0.