### PR TITLE
Add Natural Languages - Georgian and Catalan (Valencian)

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -350,6 +350,7 @@ sorted_classifiers: List[str] = [
     "Natural Language :: Bulgarian",
     "Natural Language :: Cantonese",
     "Natural Language :: Catalan",
+    "Natural Language :: Catalan (Valencian)",
     "Natural Language :: Chinese (Simplified)",
     "Natural Language :: Chinese (Traditional)",
     "Natural Language :: Croatian",

--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -361,6 +361,7 @@ sorted_classifiers: List[str] = [
     "Natural Language :: Finnish",
     "Natural Language :: French",
     "Natural Language :: Galician",
+    "Natural Language :: Georgian",
     "Natural Language :: German",
     "Natural Language :: Greek",
     "Natural Language :: Hebrew",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Natural Language :: Georgian`

## Why do you want to add this classifier?
Adding Missing Natural Languages - Georgian and Catalan (Valencian)
