### PR TITLE
Add Trove classifier for Django 5.1

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -124,6 +124,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
     "Framework :: Django CMS",
     "Framework :: Django CMS :: 3.4",
     "Framework :: Django CMS :: 3.5",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* Framework :: Django :: 5.1

## Why do you want to add this classifier?

Django 5.1 alpha was released today! See announcement: https://www.djangoproject.com/weblog/2024/may/22/django-51-alpha-1-released/
