### PR TITLE
Add Data Acquisition (DAQ) classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -719,6 +719,7 @@ sorted_classifiers: List[str] = [
     "Topic :: Scientific/Engineering :: Atmospheric Science",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Scientific/Engineering :: Chemistry",
+    "Topic :: Scientific/Engineering :: Data Acquisition (DAQ)",
     "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
     "Topic :: Scientific/Engineering :: GIS",
     "Topic :: Scientific/Engineering :: Human Machine Interfaces",


### PR DESCRIPTION
Adds a classifiers for software packages that provide or work with DAQ systems (https://en.wikipedia.org/wiki/Data_acquisition).

Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Topic :: Scientific/Engineering :: Data Acquisition (DAQ)`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

Data acquisition (DAQ) systems are common place to read data from sensors or other data sources. While typically a lot of DAQ software is written in low-level programming languages, writing DAQ software in Python is getting more common. A simple search for keywords like "data acquisition", "sensor", "readout" and "daq" and  reveal many packages that could use such a classifier.

The current classifiers are not sufficient: searching for "data" only reveals three database and a framework entry, "hardware" doesn't include any readout classifiers and in scientific/engineering are many DAQ-related classifiers (like "physics", "information analysis"), but none that actually provide a clear indication for hardware/DAQ-related packages.