### PR TITLE
Add Odoo 18 trove classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -173,6 +173,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Odoo :: 15.0",
     "Framework :: Odoo :: 16.0",
     "Framework :: Odoo :: 17.0",
+    "Framework :: Odoo :: 18.0",
     "Framework :: OpenTelemetry",
     "Framework :: OpenTelemetry :: Distros",
     "Framework :: OpenTelemetry :: Exporters",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Odoo :: 18.0`

## Why do you want to add this classifier?

Every fall, a new Odoo release lands. the next one is scheduled for early October.