### PR TITLE
Add classifier for MIT-CMU licence

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -315,6 +315,7 @@ sorted_classifiers: List[str] = [
     "License :: OSI Approved :: Jabber Open Source License",
     "License :: OSI Approved :: MIT License",
     "License :: OSI Approved :: MIT No Attribution License (MIT-0)",
+    "License :: OSI Approved :: MIT-CMU License",
     "License :: OSI Approved :: MITRE Collaborative Virtual Workspace License (CVW)",
     "License :: OSI Approved :: MirOS License (MirOS)",
     "License :: OSI Approved :: Motosoto License",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `License :: OSI Approved :: MIT-CMU License`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

We discovered this is the licence used by Pillow:

* https://github.com/python-pillow/Pillow/issues/7942

We have had it approved by OSI:

* https://opensource.org/license/cmu-license
* https://lists.opensource.org/pipermail/license-review_lists.opensource.org/2024-October/005560.html
* https://lists.opensource.org/pipermail/license-review_lists.opensource.org/2024-October/005562.html

---

If at all possible, it would be wonderful if this was released in time for our quarterly release this Tuesday (2024-10-15), but I understand this is a very notice so may not be doable :)
