### PR TITLE
Add upcoming django CMS version

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -141,6 +141,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Django CMS :: 3.11",
     "Framework :: Django CMS :: 4.0",
     "Framework :: Django CMS :: 4.1",
+    "Framework :: Django CMS :: 4.2",
     "Framework :: FastAPI",
     "Framework :: Flake8",
     "Framework :: Flask",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: Django CMS :: 4.2`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

This classifier is necessary for the upcoming next major community version of django CMS.