### PR TITLE
Add CUDA 12.6 classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -58,6 +58,7 @@ sorted_classifiers: List[str] = [
     "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.3",
     "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.4",
     "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.5",
+    "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.6",
     "Environment :: Handhelds/PDA's",
     "Environment :: MacOS X",
     "Environment :: MacOS X :: Aqua",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.6`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

New version: https://developer.nvidia.com/cuda-toolkit-archive
