### PR TITLE
Add "Framework :: Plone :: 6.2" classifier.

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -200,6 +200,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Plone :: 5.3",
     "Framework :: Plone :: 6.0",
     "Framework :: Plone :: 6.1",
+    "Framework :: Plone :: 6.2",
     "Framework :: Plone :: Addon",
     "Framework :: Plone :: Core",
     "Framework :: Plone :: Distribution",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Plone :: 6.2`

## Why do you want to add this classifier?

Classifiers for Plone 3.2 to 6.1 are already there.  Planning for 6.2 has started, see [GitHub project board](https://github.com/orgs/plone/projects/34), and some packages have already been released that could use this new classifier.

Thanks!