### PR TITLE
Add new django CMS release, called 5.0

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -874,6 +874,7 @@ classifiers: Set[str] = set(sorted_classifiers)
 # A mapping from the deprecated classifier name to a list of zero or more valid
 # classifiers that should replace it
 deprecated_classifiers: Dict[str, List[str]] = {
+    "Framework :: Django CMS :: 4.1": ["Framework :: Django CMS :: 5.0"],
     "License :: OSI Approved :: Intel Open Source License": [],
     "License :: OSI Approved :: Jabber Open Source License": [],
     "License :: OSI Approved :: MITRE Collaborative Virtual Workspace License (CVW)": [],

--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -874,7 +874,7 @@ classifiers: Set[str] = set(sorted_classifiers)
 # A mapping from the deprecated classifier name to a list of zero or more valid
 # classifiers that should replace it
 deprecated_classifiers: Dict[str, List[str]] = {
-    "Framework :: Django CMS :: 4.1": ["Framework :: Django CMS :: 5.0"],
+    "Framework :: Django CMS :: 4.2": ["Framework :: Django CMS :: 5.0"],
     "License :: OSI Approved :: Intel Open Source License": [],
     "License :: OSI Approved :: Jabber Open Source License": [],
     "License :: OSI Approved :: MITRE Collaborative Virtual Workspace License (CVW)": [],

--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -142,7 +142,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Django CMS :: 3.11",
     "Framework :: Django CMS :: 4.0",
     "Framework :: Django CMS :: 4.1",
-    "Framework :: Django CMS :: 4.2",
+    "Framework :: Django CMS :: 5.0",
     "Framework :: FastAPI",
     "Framework :: Flake8",
     "Framework :: Flask",


### PR DESCRIPTION
Request to add update a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* "Framework :: Django CMS :: 5.0"

## Why do you want to add this classifier?

This is actually a proposed change: django CMS' next release is 5.0, expected End of March. It had originally be planned to be called 4.2. 

There are no existing packages on pypi using the `"Framework :: Django CMS :: 4.2"` classifier, hence to keep the list lean, I changed the name.

Further reading:

* https://www.django-cms.org/en/blog/2025/02/27/why-django-cms-next-version-will-be-5-0/