### PR TITLE
Add Pyodide framework

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -213,6 +213,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Pydantic :: 1",
     "Framework :: Pydantic :: 2",
     "Framework :: Pylons",
+    "Framework :: Pyodide",
     "Framework :: Pyramid",
     "Framework :: Pytest",
     "Framework :: Review Board",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: Pyodide`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

Pyodide is a Python distribution for the browser and Node.js based on WebAssembly and Emscripten. In Python 3.14, Emscripten will return to a tier 3 platform for CPython, and cibuildwheel currently supports building wheels against Pyodide.

There are packages built for the Pyodide ecosystem. Examples include [pyodide-build](https://pypi.org/project/pyodide-build/), [micropip](https://pypi.org/project/micropip/), [pytest-pyodide](https://pypi.org/project/pytest-pyodide), and some packages that support the Pyodide environment, such as [urllib3](https://pypi.org/project/urllib3/) and [zengl](https://pypi.org/project/zengl/).
