### PR TITLE
Add Model Context Protocol framework

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -165,6 +165,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Masonite",
     "Framework :: Matplotlib",
     "Framework :: MkDocs",
+    "Framework :: Model Context Protocol",
     "Framework :: Nengo",
     "Framework :: Odoo",
     "Framework :: Odoo :: 8.0",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Model Context Protocol`

## Why do you want to add this classifier?

Model Context Protocol is an open standard for AI applications
to interact with context providing 'servers'. The project
is well adopted, see (https://github.com/modelcontextprotocol/python-sdk).
Hundreds of servers have been developed using the SDK.
We want to help developers of servers to classify their
servers in PyPi accordingly.
