### PR TITLE
add __all__ to declare public API

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -890,3 +890,10 @@ deprecated_classifiers: Dict[str, List[str]] = {
 all_classifiers: List[str] = sorted(
     sorted_classifiers + list(deprecated_classifiers.keys())
 )
+
+__all__ = [
+    "all_classifiers",
+    "deprecated_classifiers",
+    "sorted_classifiers",
+    "sorted_classifiers",
+]

--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -893,7 +893,7 @@ all_classifiers: List[str] = sorted(
 
 __all__ = [
     "all_classifiers",
+    "classifiers",
     "deprecated_classifiers",
-    "sorted_classifiers",
     "sorted_classifiers",
 ]


### PR DESCRIPTION
## Before

``` console
$ pydoc trove_classifiers
Help on package trove_classifiers:

NAME
    trove_classifiers

PACKAGE CONTENTS
    __main__

DATA
    Dict = typing.Dict
        A generic version of dict.

    List = typing.List
        A generic version of list.

    Set = typing.Set
        A generic version of set.

    __annotations__ = {'all_classifiers': typing.List[str], 'classifiers':...
    all_classifiers = ['Development Status :: 1 - Planning', 'Development ...
    classifiers = {'Development Status :: 1 - Planning', 'Development Stat...
    deprecated_classifiers = {'Framework :: Django CMS :: 4.2': ['Framewor...
    sorted_classifiers = ['Development Status :: 1 - Planning', 'Developme...
```

## After

``` console
$ pydoc trove_classifiers
Help on package trove_classifiers:

NAME
    trove_classifiers

PACKAGE CONTENTS
    __main__

DATA
    __all__ = ['all_classifiers', 'deprecated_classifiers', 'sorted_classi...
    __annotations__ = {'all_classifiers': typing.List[str], 'classifiers':...
    all_classifiers = ['Development Status :: 1 - Planning', 'Development ...
    deprecated_classifiers = {'Framework :: Django CMS :: 4.2': ['Framewor...
    sorted_classifiers = ['Development Status :: 1 - Planning', 'Developme...
```
