### PR TITLE
Add classifier for Wagtail 7

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -240,6 +240,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Wagtail :: 4",
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
+    "Framework :: Wagtail :: 7",
     "Framework :: ZODB",
     "Framework :: Zope",
     "Framework :: Zope2",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Wagtail :: 7`

## Why do you want to add this classifier?

[Wagtail 7.0](https://docs.wagtail.org/en/latest/releases/7.0.html) is scheduled for release on 6th May 2025. Wagtail follows SemVer, and this new major release includes breaking changes and removal of deprecated APIs. A version-specific classifier will assist Wagtail site developers in locating third-party add-on packages that have been verified as compatible with Wagtail 7.