### PR TITLE
Add entry point to enable installing with pipx or uvx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,7 @@ setup(
     package_data={"": ["py.typed"]},
     use_calver="%Y.%m.%d.%H",
     setup_requires=["calver"],
+    entry_points={
+        "console_scripts": ["trove-classifiers=trove_classifiers.__main__:cli"],
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,5 @@ setup(
     setup_requires=["calver"],
     entry_points={
         "console_scripts": ["trove-classifiers=trove_classifiers.__main__:cli"],
-    }
+    },
 )

--- a/src/trove_classifiers/__main__.py
+++ b/src/trove_classifiers/__main__.py
@@ -1,9 +1,10 @@
 from trove_classifiers import sorted_classifiers
 
+
 def cli() -> None:
     for classifier in sorted_classifiers:
         print(classifier)
 
+
 if __name__ == "__main__":
     cli()
-

--- a/src/trove_classifiers/__main__.py
+++ b/src/trove_classifiers/__main__.py
@@ -1,4 +1,9 @@
 from trove_classifiers import sorted_classifiers
 
-for classifier in sorted_classifiers:
-    print(classifier)
+def cli():
+    for classifier in sorted_classifiers:
+        print(classifier)
+
+if __name__ == "__main__":
+    cli()
+

--- a/src/trove_classifiers/__main__.py
+++ b/src/trove_classifiers/__main__.py
@@ -1,6 +1,6 @@
 from trove_classifiers import sorted_classifiers
 
-def cli():
+def cli() -> None:
     for classifier in sorted_classifiers:
         print(classifier)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,7 @@ def test_entry_point():
 
 
 def test_module_run_is_entry_point():
+    """Compare that module run output is the same as entry point output."""
     module_run_proc = subprocess.run(
         [f"{BINDIR}/python", "-m", "trove_classifiers"],
         capture_output=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,12 +11,12 @@ BINDIR = Path(sys.executable).parent
 
 def test_module_run():
     """Simple test for no error when running the module. Output is not validated."""
-    subprocess.check_call(["python", "-m", "trove_classifiers"])
+    subprocess.check_call([f"{BINDIR}/python", "-m", "trove_classifiers"])
 
 
 def test_entry_point():
     """Simple test for no error when calling the entry point. Output is not validated."""
-    subprocess.check_call("trove-classifiers")
+    subprocess.check_call(f"{BINDIR}/trove-classifiers")
 
 
 def test_module_run_is_entry_point():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,10 @@ calling the entry point produce equivalent output.
 """
 
 import subprocess
+import sys
+from pathlib import Path
+
+BINDIR = Path(sys.executable).parent
 
 
 def test_module_run():
@@ -17,9 +21,11 @@ def test_entry_point():
 
 def test_module_run_is_entry_point():
     module_run_proc = subprocess.run(
-        ["python", "-m", "trove_classifiers"], capture_output=True, encoding="utf-8"
+        [f"{BINDIR}/python", "-m", "trove_classifiers"],
+        capture_output=True,
+        encoding="utf-8",
     )
     entry_point_proc = subprocess.run(
-        "trove-classifiers", capture_output=True, encoding="utf-8"
+        f"{BINDIR}/trove-classifiers", capture_output=True, encoding="utf-8"
     )
     assert module_run_proc.stdout == entry_point_proc.stdout


### PR DESCRIPTION
This is a further iteration of the `python -m trove_classifiers` feature from #23. This PR enables installing trove-classifiers as a tool with `pipx` or `uvx`, so people can just install it and then run, e.g., `trove-classifiers | grep Django`.