### PR TITLE
Add several missing languages

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -353,6 +353,7 @@ sorted_classifiers: List[str] = [
     "License :: Repoze Public License",
     "Natural Language :: Afrikaans",
     "Natural Language :: Arabic",
+    "Natural Language :: Armenian",
     "Natural Language :: Basque",
     "Natural Language :: Bengali",
     "Natural Language :: Bosnian",
@@ -368,6 +369,7 @@ sorted_classifiers: List[str] = [
     "Natural Language :: Dutch",
     "Natural Language :: English",
     "Natural Language :: Esperanto",
+    "Natural Language :: Estonian",
     "Natural Language :: Finnish",
     "Natural Language :: French",
     "Natural Language :: Galician",
@@ -412,6 +414,7 @@ sorted_classifiers: List[str] = [
     "Natural Language :: Ukrainian",
     "Natural Language :: Urdu",
     "Natural Language :: Vietnamese",
+    "Natural Language :: Yiddish"
     "Operating System :: Android",
     "Operating System :: BeOS",
     "Operating System :: MacOS",

--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -414,7 +414,7 @@ sorted_classifiers: List[str] = [
     "Natural Language :: Ukrainian",
     "Natural Language :: Urdu",
     "Natural Language :: Vietnamese",
-    "Natural Language :: Yiddish"
+    "Natural Language :: Yiddish",
     "Operating System :: Android",
     "Operating System :: BeOS",
     "Operating System :: MacOS",


### PR DESCRIPTION
Request to add three new Trove classifiers.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Natural Language :: Armenian`
* `Natural Language :: Estonian`
* `Natural Language :: Yiddish`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

Close #214.
