### PR TITLE
Add classifier for CUDA 13

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -59,6 +59,7 @@ sorted_classifiers: List[str] = [
     "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.4",
     "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.5",
     "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.6",
+    "Environment :: GPU :: NVIDIA CUDA :: 13",
     "Environment :: Handhelds/PDA's",
     "Environment :: MacOS X",
     "Environment :: MacOS X :: Aqua",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Environment :: GPU :: NVIDIA CUDA :: 13`

## Why do you want to add this classifier?
[CUDA 13.0.0](https://pypi.org/project/nvidia-cuda-runtime) released on August 4th, 2025.
Packages linking to CUDA 13.x can use this classifier to indicate compatibility.

`make test` and `make lint` passed.

A package upload was already rejected with
>  'Environment :: GPU :: NVIDIA CUDA :: 13' is not a valid classifier.
> See https://packaging.python.org/specifications/core-metadata for more information.  

Thank you!

