### PR TITLE
Add Django 6 classifiers to trove_classifiers

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -132,6 +132,8 @@ sorted_classifiers: List[str] = [
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6",
+    "Framework :: Django :: 6.0",
     "Framework :: Django CMS",
     "Framework :: Django CMS :: 3.4",
     "Framework :: Django CMS :: 3.5",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->

* `Framework :: Django :: 6`
* `Framework :: Django :: 6.0`


## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

The Django 6.0 feature freeze is just a couple of weeks away, and packages are already preparing compatibility releases, which require the Trove classifier to be in place. 

For consistency with previous release cycles we add both the specific `6.0` and general `6` classifier at this point. 