### PR TITLE
Add support for Odoo 19.0 in classifiers

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -182,6 +182,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Odoo :: 16.0",
     "Framework :: Odoo :: 17.0",
     "Framework :: Odoo :: 18.0",
+    "Framework :: Odoo :: 19.0",
     "Framework :: OpenTelemetry",
     "Framework :: OpenTelemetry :: Distros",
     "Framework :: OpenTelemetry :: Exporters",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Odoo :: 19.0`

## Why do you want to add this classifier?

The Odoo 19.0 branch has been created and will be officially released next week: https://github.com/odoo/odoo/tree/19.0