### PR TITLE
Add "Topic :: Internet :: GURT"

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -665,6 +665,7 @@ sorted_classifiers: List[str] = [
     "Topic :: Internet :: Name Service (DNS)",
     "Topic :: Internet :: Proxy Servers",
     "Topic :: Internet :: WAP",
+    "Topic :: Internet :: GURT",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Browsers",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Topic :: Internet :: GURT`

## Why do you want to add this classifier?
Recently the YouTuber FaceDev created an alternative protocol to HTTP, and it already has somewhat significant use, with thousands of registered domains and multiple major projects already running.

I am currently writing a Python implementation of its protocol, providing both a client and server, I have noticed other projects beginning to pop up on PyPi, such as `gurtlib`.

I believe it may be beneficial for the trove specifier `Topic :: Internet :: GURT` to be created, allowing projects for this protocol to be easily searchable, as more appear. Also, it would fit in with `Topic :: Internet :: WWW/HTTP`.
