### PR TITLE
Add classifier for Zope 6

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -254,6 +254,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Zope :: 3",
     "Framework :: Zope :: 4",
     "Framework :: Zope :: 5",
+    "Framework :: Zope :: 6",
     "Framework :: aiohttp",
     "Framework :: cocotb",
     "Framework :: napari",


### PR DESCRIPTION
Fixes #228
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: Zope :: 6`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->
We are close to releasing Zope version 6.
