### PR TITLE
Update __init__.py to add Cygwin as a classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -14,6 +14,7 @@ sorted_classifiers: List[str] = [
     "Environment :: Console :: Framebuffer",
     "Environment :: Console :: Newt",
     "Environment :: Console :: svgalib",
+    "Environment :: Cygwin (MS Windows)",
     "Environment :: GPU",
     "Environment :: GPU :: NVIDIA CUDA",
     "Environment :: GPU :: NVIDIA CUDA :: 1.0",


### PR DESCRIPTION
Add "Environment :: Cygwin (MS Windows)" as a classifier as some modules, such as mine, work on Windows but only via the Cygwin POSIX layer (www.cygwin.com)

Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* 'Environment :: Cygwin (MS Winows)'

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->
My module (getdevinfo) works on Windows but only via the Cygwin POSIX layer. I don't know how many other modules this is true for, but I imagine, given the number of Linux-only libraries and applications that can be run under Cygwin, that the list could potentially be quite big.