### PR TITLE
Add Basilisp as a Programming Language classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -472,6 +472,7 @@ sorted_classifiers: List[str] = [
     "Programming Language :: Assembly",
     "Programming Language :: Awk",
     "Programming Language :: Basic",
+    "Programming Language :: Basilisp",
     "Programming Language :: C",
     "Programming Language :: C#",
     "Programming Language :: C++",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Programming Language :: Basilisp`

## Why do you want to add this classifier?
[Basilisp](http://docs.basilisp.org/) is a Clojure-compatible Lisp dialect which compiles down to Python. I first started work on it in 2016 and it has recently gained interest in the Clojure community for people looking to benefit from the rich Python ecosystem of packages.

Similar to Hy (added in #173), Basilisp uses Python's packaging system and Basilisp can provide features not usable in pure Python. If people wish to upload Basilisp packages to PyPI, it would be helpful to tag those packages with a specific classifier.