### PR TITLE
Add LGPL-2.1-only and LGPL-2.1-or-later classifiers

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -321,6 +321,8 @@ sorted_classifiers: List[str] = [
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)",
     "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
+    "License :: OSI Approved :: GNU Lesser General Public License v2.1 only (LGPL-2.1-only)",
+    "License :: OSI Approved :: GNU Lesser General Public License v2.1 or later (LGPL-2.1-or-later)",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
     "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `License :: OSI Approved :: GNU Lesser General Public License v2.1 only (LGPL-2.1-only)`
* `License :: OSI Approved :: GNU Lesser General Public License v2.1 or later (LGPL-2.1-or-later)`

## Why do you want to add this classifier?

I need to license my project under LGPL-2.1-only, but there's no appropriate classifier. Currently, I'm forced to use `License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)`, which incorrectly suggests my code can be relicensed under LGPL-3.0+.

My `pyproject.toml` specifies `license = "LGPL-2.1-only"`, but the trove classifier contradicts this. This has been a recurring issue for me and organizations I work with due to corporate licensing requirements.

LGPL-2.1 and LGPL-3.0 have significant compatibility differences. I need to ensure my library remains under LGPL-2.1 terms only and cannot be relicensed to LGPL-3.0 by downstream users.

PyPI has comprehensive GNU license classifiers for GPL (v2, v2+, v3, v3+), AGPL (v3, v3+), and LGPL (v2, v2+, v3, v3+), but LGPL-2.1 variants are missing despite being commonly used.

Related issue: #234