### PR TITLE
Add Framework::VapourSynth classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -244,6 +244,7 @@ sorted_classifiers: List[str] = [
     "Framework :: TurboGears :: Applications",
     "Framework :: TurboGears :: Widgets",
     "Framework :: Twisted",
+    "Framework :: VapourSynth",
     "Framework :: Wagtail",
     "Framework :: Wagtail :: 1",
     "Framework :: Wagtail :: 2",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework::VapourSynth`

## Why do you want to add this classifier?
[VapourSynth](https://www.vapoursynth.com/doc/introduction.html) is a video processing framework that allows users to perform complex video filtering with simple python scripts. It is designed to be extensible and since its initial release in 2012 it has had hundreds of plugins written by the community, implementing a wide array of filters.

Historically VapourSynth was installed as a system-wide application separate from any python install, and community plugins were similarly installed system-wide. This plugin installation was commonly assisted by [vsrepo](https://github.com/vapoursynth/vsrepo) (see the `local` directory for the plugin list; each json file represents a plugin). However with the most recent release, the install pattern [has changed](https://www.vapoursynth.com/2026/03/26/new-packaging-and-install-methods-in-r74/) and VapourSynth can now be full installed from PyPI with support for loading plugins that are also installed from PyPI.

There are only a few plugins that have been packaged and deployed on PyPI so far (e.g. [vapoursynth-bestsource](https://pypi.org/project/vapoursynth-bestsource/) & [vsfpng](https://pypi.org/project/vsfpng/)) as the full release is still [very new](https://github.com/vapoursynth/vapoursynth/releases/tag/R74), but it is expected that at minimum the 47 plugins required for the full suite of [vsjetpack](https://github.com/Jaded-Encoding-Thaumaturgy/vs-jetpack?tab=readme-ov-file#dependencies) functionality will be prioritized for porting, so that its dependencies can finally be fully expressed as python requirements resolved by pip et al.

Going forward it would be broadly useful for users to be able to browse a list of VapourSynth plugins (as they used to do with the bespoke `vsrepo available` command) and a new classifier seems like the cleanest way to enable such listing via PyPI search.