### PR TITLE
Request to add dot-less version of "Topic :: Scientific/Engineering :: Medical Science Apps." for consistency

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -757,7 +757,7 @@ sorted_classifiers: List[str] = [
     "Topic :: Scientific/Engineering :: Instrument Drivers :: IVI Conformant",
     "Topic :: Scientific/Engineering :: Interface Engine/Protocol Translator",
     "Topic :: Scientific/Engineering :: Mathematics",
-    "Topic :: Scientific/Engineering :: Medical Science Apps.",
+    "Topic :: Scientific/Engineering :: Medical Science Apps",
     "Topic :: Scientific/Engineering :: Oceanography",
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Scientific/Engineering :: Quantum Computing",
@@ -909,6 +909,9 @@ deprecated_classifiers: Dict[str, List[str]] = {
     "License :: OSI Approved :: X.Net License": [],
     "Natural Language :: Ukranian": ["Natural Language :: Ukrainian"],
     "Topic :: Communications :: Chat :: AOL Instant Messenger": [],
+    "Topic :: Scientific/Engineering :: Medical Science Apps.": [
+        "Topic :: Scientific/Engineering :: Medical Science Apps",
+    ],
 }
 
 


### PR DESCRIPTION
Currently, the classifier `Topic :: Scientific/Engineering :: Medical Science Apps.` is the only one in its hierarchy that ends with a period `.`. This is inconsistent with other neighboring classifiers like Bio-Informatics or Information Analysis.

While I understand many packages already use the version with the period, could we consider adding a new, dot-less version Topic :: Scientific/Engineering :: Medical Science Apps as the preferred one, and eventually deprecating the old one? This would improve the developer experience and keep the naming conventions consistent across the platform.