### PR TITLE
Add Trove classifier for Python 3.16

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -542,6 +542,7 @@ sorted_classifiers: List[str] = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3.15",
+    "Programming Language :: Python :: 3.16",
     "Programming Language :: Python :: Free Threading",
     "Programming Language :: Python :: Free Threading :: 1 - Unstable",
     "Programming Language :: Python :: Free Threading :: 2 - Beta",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Programming Language :: Python :: 3.15`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

Python 3.15 is in beta which means the `main` branch is now 3.16:

* https://discuss.python.org/t/python-3-15-0-beta-1-is-here/107231
* https://github.com/python/cpython/commit/f5c75351def83602b5b23c1fba361b7de8ffabc7
