### PR TITLE
Add classifier for Wagtail 8

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -252,6 +252,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
     "Framework :: Wagtail :: 7",
+    "Framework :: Wagtail :: 8",
     "Framework :: ZODB",
     "Framework :: Zope",
     "Framework :: Zope2",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: Wagtail :: 8`

## Why do you want to add this classifier?
<!--
    Include a brief explanation to justify your request.
    Why do the current classifiers not meet your need?
    How many projects do you expect to use this new classifier?
    If you are requesting multiple classifiers, why do you need more than one?
-->

[Wagtail 8.0](https://docs.wagtail.org/en/latest/releases/8.0.html) is scheduled for release on 3rd August 2026. Wagtail follows SemVer, and this new major release includes breaking changes and removal of deprecated APIs. A version-specific classifier will assist Wagtail site developers in locating third-party add-on packages that have been verified as compatible with Wagtail 8.

Last request for ref: #210