### PR TITLE
Add classifier for Django 6.1

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -135,6 +135,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6",
     "Framework :: Django :: 6.0",
+    "Framework :: Django :: 6.1",
     "Framework :: Django CMS",
     "Framework :: Django CMS :: 3.4",
     "Framework :: Django CMS :: 3.5",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

<!-- Replace the following with the name of your classifier -->
* `Framework :: Django :: 6.1`

## Why do you want to add this classifier?
Django 6.1 alpha 1 was released today!
