### PR TITLE
Add classifier for Sesotho

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -416,6 +416,7 @@ sorted_classifiers: List[str] = [
     "Natural Language :: Romanian",
     "Natural Language :: Russian",
     "Natural Language :: Serbian",
+    "Natural Language :: Sesotho",
     "Natural Language :: Slovak",
     "Natural Language :: Slovenian",
     "Natural Language :: Spanish",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Natural Language :: Sesotho`

## Why do you want to add this classifier?

Snowballstem and PyStemmer recently gained a stemming algorithm for Sesotho.