### PR TITLE
Add Plone 6.3 classifier.

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -213,6 +213,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Plone :: 6.0",
     "Framework :: Plone :: 6.1",
     "Framework :: Plone :: 6.2",
+    "Framework :: Plone :: 6.3",
     "Framework :: Plone :: Addon",
     "Framework :: Plone :: Core",
     "Framework :: Plone :: Distribution",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Plone :: 6.3`

## Why do you want to add this classifier?

I have released [Plone 6.2.0](https://plone.org/download/releases/6.2.0) this week.  We are now starting Plone 6.3 development, and need to start marking our packages with it.

Thanks!