### PR TITLE
Restrict OIDC token to publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-publish:
+  build:
     if: github.repository_owner == 'pypa'
     runs-on: ubuntu-latest
     permissions:
-       # IMPORTANT: this permission is mandatory for trusted publishing
-       id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -29,6 +28,25 @@ jobs:
       run: pip install -U setuptools wheel build calver
     - name: Build
       run: python -m build .
+    - name: Upload dist
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: dist/
+        if-no-files-found: error
+  publish:
+    if: github.repository_owner == 'pypa'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+    - name: Download dist
+      uses: actions/download-artifact@v4
+      with:
+        name: dist
+        path: dist
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
   release:


### PR DESCRIPTION
The GH OIDC token used for Trusted Publishing should not be available to non-publishing steps. This PR removes it from the steps that install the dependencies and build the project, so that it's only available during PyPI publishing.

cc @miketheman