### PR TITLE
Add pre-commit classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -218,6 +218,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Plone :: Core",
     "Framework :: Plone :: Distribution",
     "Framework :: Plone :: Theme",
+    "Framework :: Pre-Commit"
     "Framework :: PySimpleGUI",
     "Framework :: PySimpleGUI :: 4",
     "Framework :: PySimpleGUI :: 5",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Pre-Commit`

## Why do you want to add this classifier?
For pre-commit hooks integrated into the pre-commit/prek ecosystem, such as [asottile/pyupgrade](https://github.com/asottile/pyupgrade), [astral-sh/ruff-pre-commit](https://github.com/astral-sh/ruff-pre-commit), [adamchainz/django-upgrade](https://github.com/adamchainz/django-upgrade), [rhysd/actionlint](https://github.com/rhysd/actionlint). These repositories usually declare a `.pre-commit-hooks.yaml` at the project root, and this change makes for easier discovery.
