### PR TITLE
Add Hippocratic License classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -296,6 +296,7 @@ sorted_classifiers: List[str] = [
     "License :: Freeware",
     "License :: GUST Font License 1.0",
     "License :: GUST Font License 2006-09-30",
+    "License :: Hippocratic License",
     "License :: Netscape Public License (NPL)",
     "License :: Nokia Open Source License (NOKOS)",
     "License :: OSI Approved",


### PR DESCRIPTION
Closes #12

This adds the \License :: Hippocratic License\ classifier to the set of available classifiers, inserted in the correct alphabetical position within the \sorted_classifiers\ list.

The Hippocratic License (https://firstdonoharm.dev) restricts use by parties that infringe on the declaration of human rights, and adding it as a classifier lets projects choose it when publishing and lets users browse for it programmatically.