### PR TITLE
Add Framework :: SageMath classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -233,6 +233,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Robot Framework",
     "Framework :: Robot Framework :: Library",
     "Framework :: Robot Framework :: Tool",
+    "Framework :: SageMath",
     "Framework :: Scrapy",
     "Framework :: Setuptools Plugin",
     "Framework :: Sphinx",


### PR DESCRIPTION
Adds the \Framework :: SageMath\ Trove classifier requested in #18.

SageMath (sagemath.org) is one of the most widely used open-source computer algebra systems, and pip is now the preferred way to distribute packages built on it. A dedicated classifier will make SageMath-related projects discoverable on PyPI, replacing the ambiguous legacy \sage\ name.

- Adds \Framework :: SageMath\ to \src/trove_classifiers/__init__.py\ in alphabetical order
- \in/sort.py\ passes

Fixes #18