### PR TITLE
Add Framework :: Pylint classifier

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -225,6 +225,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Pydantic",
     "Framework :: Pydantic :: 1",
     "Framework :: Pydantic :: 2",
+    "Framework :: Pylint",
     "Framework :: Pylons",
     "Framework :: Pyodide",
     "Framework :: Pyramid",


### PR DESCRIPTION
Adds the \Framework :: Pylint\ Trove classifier requested in #26.

Pylint supports custom plugins (e.g. pylint-django, pytest-pylint) and there are many community packages on PyPI that would benefit from being discoverable via a dedicated classifier, just as Flake8 has its own.

- Adds \Framework :: Pylint\ to \src/trove_classifiers/__init__.py\ in alphabetical order
- \in/sort.py\ passes

Fixes #26