### PR TITLE
tests: dynamically locate trove-classifiers CLI entry point across platforms (#219)

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,11 +2,31 @@
 calling the entry point produce equivalent output.
 """
 
+import shutil
 import subprocess
 import sys
+import sysconfig
 from pathlib import Path
+from typing import Optional
 
-BINDIR = Path(sys.executable).parent
+import pytest
+
+
+def _get_entry_point() -> Optional[str]:
+    exe = shutil.which("trove-classifiers")
+    if exe:
+        return exe
+    candidates = [
+        Path(sysconfig.get_path("scripts")),
+        Path(sys.executable).parent,
+        Path(sys.executable).parent / "Scripts",
+        Path(sys.executable).parent / "bin",
+    ]
+    for candidate_dir in candidates:
+        exe = shutil.which("trove-classifiers", path=str(candidate_dir))
+        if exe:
+            return exe
+    return None
 
 
 def test_module_run():
@@ -16,17 +36,31 @@ def test_module_run():
 
 def test_entry_point():
     """Simple test for no error when calling the entry point. Output is not validated."""
-    subprocess.check_call(f"{BINDIR}/trove-classifiers")
+    entry_point = _get_entry_point()
+    if not entry_point:
+        pytest.skip(
+            "trove-classifiers CLI entry point not found in PATH or scripts directory"
+        )
+    subprocess.check_call([entry_point])
 
 
 def test_module_run_is_entry_point():
     """Compare that module run output is the same as entry point output."""
+    entry_point = _get_entry_point()
+    if not entry_point:
+        pytest.skip(
+            "trove-classifiers CLI entry point not found in PATH or scripts directory"
+        )
     module_run_proc = subprocess.run(
         [sys.executable, "-m", "trove_classifiers"],
         capture_output=True,
         encoding="utf-8",
+        check=True,
     )
     entry_point_proc = subprocess.run(
-        f"{BINDIR}/trove-classifiers", capture_output=True, encoding="utf-8"
+        [entry_point],
+        capture_output=True,
+        encoding="utf-8",
+        check=True,
     )
     assert module_run_proc.stdout == entry_point_proc.stdout


### PR DESCRIPTION
Fixes #219

### Summary
`tests/test_cli.py` previously constructed the path to the `trove-classifiers` binary by concatenating `f"{Path(sys.executable).parent}/trove-classifiers"`.

This fails in multiple common environments:
1. User-level installations (`pip install --user`), where `sys.executable` is e.g. `/usr/bin/python3` but the console script is installed in `~/.local/bin/`.
2. Windows environments, where console scripts reside in `Scripts/` with `.exe` extensions.
3. Development / clean checkout environments where the entry point script has not yet been installed into `PATH`.

### Changes
* Replaced hardcoded path concatenation in `tests/test_cli.py` with `_get_entry_point()`, using `shutil.which` across `PATH` and common script directories (`sysconfig.get_path("scripts")`, `Scripts`, `bin`).
* If the console script entry point is not present in the environment, the entry point tests skip gracefully instead of raising `FileNotFoundError`.
* Passed command arguments as lists `[entry_point]` for safe cross-platform execution.
